### PR TITLE
fix: remove paths filter from validate-registry workflow

### DIFF
--- a/.github/workflows/validate-registry.yml
+++ b/.github/workflows/validate-registry.yml
@@ -5,11 +5,8 @@ on:
     branches:
       - main
       - dev
-    paths:
-      - '.opencode/**'
-      - 'registry.json'
-      - 'scripts/validate-registry.sh'
-      - 'scripts/auto-detect-components.sh'
+    # Removed paths filter - this check is required by repository ruleset
+    # so it must run on ALL PRs to prevent blocking merges
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

Fixes the issue where PRs are blocked indefinitely when they don't modify registry-related files.

## Problem

The `validate-and-update` check is **required** by the repository ruleset for all PRs to `main`, but the workflow only runs when specific paths are modified:
- `.opencode/**`
- `registry.json`
- `scripts/validate-registry.sh`
- `scripts/auto-detect-components.sh`

This causes PRs that don't touch these files (like PR #26) to be blocked forever with "Waiting for status to be reported".

## Solution

Removed the `paths` filter from the workflow so it runs on **all PRs** to satisfy the required status check.

## Impact

- ✅ All PRs will now have the validate-and-update check run
- ✅ No more indefinite blocking on PRs
- ⚠️ Workflow will run more frequently (but it's fast and only validates registry)

## Testing

Once this PR is merged, PR #26 should automatically unblock and become mergeable.