### PR TITLE
fix(ci): resolve post-merge workflow heredoc parsing issue

### DIFF
--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -111,16 +111,11 @@ jobs:
           
           # Update CHANGELOG.md
           DATE=$(date +%Y-%m-%d)
-          COMMIT_MSG=$(git log -1 --pretty=%B)
+          # Get only the first line (title) of commit message to avoid multiline issues
+          COMMIT_TITLE=$(git log -1 --pretty=%s)
           
-          # Create changelog entry
-          cat > /tmp/changelog_entry.md << EOF
-          ## [$NEW_VERSION] - $DATE
-          
-          ### Changes
-          - $COMMIT_MSG
-          
-          EOF
+          # Create changelog entry (use printf to avoid heredoc issues)
+          printf "## [%s] - %s\n\n### Changes\n- %s\n\n" "$NEW_VERSION" "$DATE" "$COMMIT_TITLE" > /tmp/changelog_entry.md
           
           # Prepend to CHANGELOG.md (after the header)
           if [ -f CHANGELOG.md ]; then


### PR DESCRIPTION
## Problem

The post-merge workflow was failing with `before: command not found` error when processing PR #42's merge commit. This happened because multiline commit messages were being inserted into a bash heredoc, causing shell parsing errors.

## Root Cause

When a PR with a detailed body (like PR #42) was merged, the full commit message including markdown formatting was inserted into:
```bash
cat > /tmp/changelog_entry.md << EOF
- $COMMIT_MSG
EOF
```

Text like "**Before:**" was interpreted as a shell command, causing the error.

## Solution

1. Use only the commit title (first line) instead of full message body
2. Replace heredoc with `printf` to avoid shell expansion issues
3. Properly escape special characters

## Changes

- Updated `.github/workflows/post-merge.yml`
- Changed from `git log -1 --pretty=%B` (full body) to `--pretty=%s` (subject only)
- Replaced heredoc with `printf` for safer string handling

## Testing

This fix will allow the post-merge workflow to:
- ✅ Successfully parse commit messages with special characters
- ✅ Create proper changelog entries
- ✅ Bump versions correctly
- ✅ Create GitHub releases

## Related

- Fixes the error from PR #42 merge
- Enables proper version bumping (currently stuck at v0.0.2)