### PR TITLE
fix(plugin): add missing telegram-bot.ts to registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -463,6 +463,20 @@
     ],
     "plugins": [
       {
+        "id": "telegram-bot",
+        "name": "Telegram Bot Library",
+        "type": "plugin",
+        "path": ".opencode/plugin/lib/telegram-bot.ts",
+        "description": "Simple Telegram Bot wrapper for sending notifications",
+        "tags": [
+          "telegram",
+          "bot",
+          "library"
+        ],
+        "dependencies": [],
+        "category": "specialized"
+      },
+      {
         "id": "telegram-notify",
         "name": "Telegram Notifications",
         "type": "plugin",
@@ -474,7 +488,8 @@
           "integration"
         ],
         "dependencies": [
-          "tool:env"
+          "tool:env",
+          "plugin:telegram-bot"
         ],
         "category": "specialized"
       },
@@ -790,6 +805,7 @@
         "tool:env",
         "tool:gemini",
         "plugin:notify",
+        "plugin:telegram-bot",
         "plugin:telegram-notify",
         "context:essential-patterns",
         "context:project-context",
@@ -822,6 +838,7 @@
         "tool:env",
         "tool:gemini",
         "plugin:notify",
+        "plugin:telegram-bot",
         "plugin:telegram-notify",
         "context:essential-patterns",
         "context:project-context",
@@ -871,6 +888,7 @@
         "tool:env",
         "tool:gemini",
         "plugin:notify",
+        "plugin:telegram-bot",
         "plugin:telegram-notify",
         "context:essential-patterns",
         "context:project-context",


### PR DESCRIPTION
## Summary

Fixes #39 - Plugin crash on startup when using advanced profile.

## Problem

The `telegram-notify.ts` plugin imports `SimpleTelegramBot` from `./lib/telegram-bot`, but the `lib/telegram-bot.ts` file was not included in the `registry.json` component list. This caused the installer to skip downloading the required dependency, resulting in a module resolution failure that crashed the application on startup with garbled ANSI escape sequences.

## Solution

- Add `telegram-bot` as a new plugin component in `registry.json`
- Add `plugin:telegram-bot` as a dependency of `telegram-notify`
- Include `plugin:telegram-bot` in business, full, and advanced profiles

## Testing

- [x] Validated with `./scripts/registry/validate-component.sh`
- [x] Validated with `./scripts/registry/validate-registry.sh`
- [x] Verified `telegram-bot.ts` exists at `.opencode/plugin/lib/telegram-bot.ts`

**Manual testing steps:**
1. Run installer with `advanced` profile
2. Verify `~/.opencode/plugin/lib/telegram-bot.ts` is created
3. Run `opencode` - should start without crash

## Credits

- Issue reported by @FrancoStino
- Fix identified by @AVert