### PR TITLE
fixing link errors in QUICK-START.md

### DIFF
--- a/QUICK_START.md
+++ b/QUICK_START.md
@@ -252,7 +252,6 @@ Tests are evaluated by multiple evaluators:
 ## 📚 Additional Resources
 
 - [README.md](README.md) - Project overview
-- [evals/framework/SDK_EVAL_README.md](evals/framework/SDK_EVAL_README.md) - SDK documentation
 - [CHANGELOG.md](CHANGELOG.md) - Version history
 
 ---


### PR DESCRIPTION
## Description

Removed dangling links in QUICK_START..md as they currently produce 4004

I am happy to update this PR with new links.  Just let me know if my replacement is ok and suggest missing ones (I didn't locate equivalent files)

* evals/GETTING_STARTED.md -> evals/README.md  - Correct ?
* evals/ARCHITECTURE.md ->  ??  - Pls, suggest
*  evals/framework/SDK_EVAL_README.md -> evals/framework/README.md - Correct ?

Cheers

Didier



## Type of Change
- [ ] New feature (agent, command, tool)
- [ ] Bug fix
- [X ] Documentation
- [ ] Refactoring
- [ ] CI/CD

## Checklist
- [ ] Tests pass locally
- [X] Documentation updated (if needed)
- [ ] Follows [CONTRIBUTING.md](docs/contributing/CONTRIBUTING.md)

## Testing

N/A

