### PR TITLE
ci: Add advanced profile to CI smoke tests

### DIFF
--- a/.github/workflows/installer-checks.yml
+++ b/.github/workflows/installer-checks.yml
@@ -158,7 +158,7 @@ jobs:
     needs: [non-interactive-tests]
     strategy:
       matrix:
-        profile: [essential, developer, business, full]
+        profile: [essential, developer, business, full, advanced]
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
Adds the `advanced` profile to CI smoke tests to ensure comprehensive testing coverage.

## Problem
The CI/CD pipeline was only testing 4 of 5 available profiles:
- ✅ Tested: `essential`, `developer`, `business`, `full`
- ❌ Missing: `advanced`

This gap allowed issue #103 (malformed URL errors in advanced profile) to go undetected until manual testing.

## Solution
Add `advanced` to the profile smoke test matrix in `.github/workflows/installer-checks.yml`

## Why This Matters
- **Advanced profile is the most comprehensive**: 117 components vs 115 in full profile
- **Catches edge cases**: Advanced includes all components, more likely to expose integration issues
- **Prevents regressions**: Would have caught issue #103 automatically

## Changes
```yaml
profile: [essential, developer, business, full, advanced]
```

## Testing
- All 5 profiles will now be tested on every PR
- Increases CI runtime slightly but provides better coverage

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [x] CI/CD