### PR TITLE
fix: Add working admin bypass for validation checks

### DIFF
--- a/.github/workflows/validate-registry.yml
+++ b/.github/workflows/validate-registry.yml
@@ -44,15 +44,24 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
+      - name: Admin bypass check
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.skip_validation == 'true'
+        run: |
+          echo "## ✅ Validation Bypassed (Admin Override)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Validation checks skipped by maintainer." >> $GITHUB_STEP_SUMMARY
+          echo "PR: #${{ github.event.inputs.pr_number }}" >> $GITHUB_STEP_SUMMARY
+          exit 0
+      
       - name: Checkout repository (for manual runs)
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.skip_validation != 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Get PR details (for manual runs)
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != ''
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.pr_number != '' && github.event.inputs.skip_validation != 'true'
         id: get_pr
         run: |
           PR_DATA=$(gh pr view ${{ github.event.inputs.pr_number }} --json headRefName,headRepository,headRepositoryOwner)
@@ -62,6 +71,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Checkout PR branch
+        if: github.event.inputs.skip_validation != 'true'
         uses: actions/checkout@v4
         with:
           # For manual runs: use PR details from get_pr step


### PR DESCRIPTION
## Summary
Adds a working admin bypass so you can immediately unblock stuck PRs.

## Problem
- Bot PRs get stuck waiting for validation checks
- Even with `skip_validation` flag, the workflow didn't actually bypass properly
- Super annoying to deal with every time

## Solution
Make the `skip_validation` flag actually work:
- Exits successfully immediately when set to true
- Skips all validation steps
- Reports bypass in summary

## Usage
To unblock any stuck PR (like #106):
```bash
gh workflow run "Validate Registry on PR" -f pr_number=106 -f skip_validation=true
```

That's it! The check will pass and the PR will be unblocked.

## Changes
- Added "Admin bypass check" step that exits 0 when skip_validation=true
- Added skip_validation condition to all subsequent steps
- Workflow now properly respects the bypass flag

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactoring
- [x] CI/CD