### PR TITLE
fix: use official Bun setup action in CI workflow

### DIFF
--- a/.github/workflows/validate-registry.yml
+++ b/.github/workflows/validate-registry.yml
@@ -113,10 +113,12 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y jq
-          
-          # Install Bun for TypeScript validator
-          curl -fsSL https://bun.sh/install | bash
-          echo "$HOME/.bun/bin" >> $GITHUB_PATH
+      
+      - name: Install Bun
+        if: github.event.inputs.skip_validation != 'true'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
       
       - name: Make scripts executable
         if: github.event.inputs.skip_validation != 'true'


### PR DESCRIPTION
## Problem

PR #129 added the TypeScript validator but Bun wasn't being installed correctly. The manual installation in the same step doesn't update PATH until the next step, causing the validator to fail.

## Solution

Use the official `oven-sh/setup-bun@v2` action which properly:
- Installs Bun
- Updates PATH immediately
- Works reliably in GitHub Actions

## Changes

```diff
- # Install Bun for TypeScript validator
- curl -fsSL https://bun.sh/install | bash
- echo "$HOME/.bun/bin" >> $GITHUB_PATH
+ - name: Install Bun
+   uses: oven-sh/setup-bun@v2
+   with:
+     bun-version: latest
```

## Testing

This will be tested when merged - the TypeScript validator should run successfully.

## Impact

- **Fixes**: PR #128 CI failures
- **Improves**: Bun installation reliability

---

**Priority**: Critical - Blocking PR #128