### PR TITLE
fix: install dependencies in validation workflow

### DIFF
--- a/.github/workflows/validate-registry.yml
+++ b/.github/workflows/validate-registry.yml
@@ -120,6 +120,12 @@ jobs:
         with:
           bun-version: latest
       
+      - name: Install dependencies
+        if: github.event.inputs.skip_validation != 'true'
+        run: |
+          # Install root dependencies (glob package needed for validation script)
+          bun install --frozen-lockfile
+      
       - name: Make scripts executable
         if: github.event.inputs.skip_validation != 'true'
         run: |
@@ -201,7 +207,8 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           
           # Use TypeScript validator (fast and reliable)
-          if bun run scripts/registry/validate-registry.ts > /tmp/validation-output.txt 2>&1; then
+          # Run validation and capture output (show in logs AND save to file)
+          if bun run scripts/registry/validate-registry.ts 2>&1 | tee /tmp/validation-output.txt; then
             echo "validation=passed" >> $GITHUB_OUTPUT
             echo "✅ All registry paths are valid!" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
@@ -215,6 +222,8 @@ jobs:
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
             cat /tmp/validation-output.txt >> $GITHUB_STEP_SUMMARY
             echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Check the logs above for detailed error output**" >> $GITHUB_STEP_SUMMARY
             exit 1
           fi
       


### PR DESCRIPTION
## Problem

The  workflow was failing because:
1. The validation script () requires the `glob` package from `devDependencies`
2. The workflow installed Bun but never ran `bun install` to get dependencies
3. Errors were hidden because output was redirected to `/tmp/validation-output.txt`

## Solution

1. ✅ Add `bun install --frozen-lockfile` step after installing Bun
2. ✅ Use `tee` to show validation output in logs while also saving to file
3. ✅ This makes debugging CI failures much easier

## Testing

- Tested locally with Bun 1.3.8 (same as CI)
- Validation passes with dependencies installed

## Impact

This unblocks PR #151 and any future PRs that modify agents/registry.

## Note

This PR must be merged BEFORE #151 because `pull_request_target` workflows run from the base branch (main), not the PR branch.