### PR TITLE
fix(shellcheck): declare and assign separately in router.sh (SC2155)

### DIFF
--- a/.opencode/skill/project-orchestration/router.sh
+++ b/.opencode/skill/project-orchestration/router.sh
@@ -51,7 +51,8 @@ fi
 
 # Find project root
 find_project_root() {
-    local dir="$(pwd)"
+    local dir
+    dir="$(pwd)"
     while [ "$dir" != "/" ]; do
         if [ -d "$dir/.git" ] || [ -f "$dir/package.json" ]; then
             echo "$dir"


### PR DESCRIPTION
## Summary

Pre-existing ShellCheck SC2155 warning in `.opencode/skill/project-orchestration/router.sh` was blocking CI on all PRs including #230.

## Change

```bash
# Before
local dir="$(pwd)"

# After
local dir
dir="$(pwd)"
```

SC2155: Declaring and assigning a local variable in one statement masks the return value of the subshell. Splitting them is the correct fix.

## Impact

Unblocks ShellCheck CI for all open and future PRs.