### PR TITLE
fix: add missing 'question' tool to compatibility layer

### DIFF
--- a/packages/compatibility-layer/src/mappers/ToolMapper.ts
+++ b/packages/compatibility-layer/src/mappers/ToolMapper.ts
@@ -264,7 +264,7 @@ export function mapToolAccessToOAC(
  * Check if a tool name is a valid OAC tool.
  */
 function isValidOACTool(name: string): name is keyof ToolAccess {
-  const validTools = ["read", "write", "edit", "bash", "task", "grep", "glob", "patch"];
+  const validTools = ["read", "write", "edit", "bash", "task", "grep", "glob", "patch", "question"];
   return validTools.includes(name);
 }
 

--- a/packages/compatibility-layer/src/types.ts
+++ b/packages/compatibility-layer/src/types.ts
@@ -17,6 +17,7 @@ export const ToolAccessSchema = z.object({
   grep: z.boolean().optional(),
   glob: z.boolean().optional(),
   patch: z.boolean().optional(),
+  question: z.boolean().optional(),
 });
 
 // ============================================================================


### PR DESCRIPTION
## Problem
OpenCode's "question" tool is not recognized when using OpenCoder/OpenAgent integration, causing tool calls to fail validation.

## Root Cause
The "question" tool was missing from two locations in the compatibility layer:
1. \"ToolMapper.ts\": The \"isValidOACTool()\" function didn't include \"question\" in the valid tools array
2. \"types.ts\": The \"ToolAccessSchema\" Zod schema didn't define the \"question\" field

## Change
- Added \"question\" to the valid tools array in \"isValidOACTool()\"
- Added \"question: z.boolean().optional()\" to \"ToolAccessSchema\"

## Verification
- \"git diff --check\": No whitespace errors
- \"npm run build\": TypeScript compilation clean
- \"npm run test\": 583/584 tests passed (1 pre-existing failure unrelated to this fix)
- All 34 ToolMapper tests passed

## Risk/Edge Cases
- Minimal risk: The change only adds an optional field that was already expected by OpenCode
- No breaking changes - existing tools continue to work
- The "question" tool is now opt-in via the same pattern as other tools

## Issue
Fixes #268