### PR TITLE
fix: default SDK eval model fallback to grok-code-fast

### DIFF
--- a/evals/framework/src/sdk/test-runner.ts
+++ b/evals/framework/src/sdk/test-runner.ts
@@ -171,7 +171,7 @@ export class TestRunner {
       defaultTimeout: config.defaultTimeout || 60000,
       projectPath: config.projectPath || gitRoot,
       runEvaluators: config.runEvaluators ?? true,
-      defaultModel: config.defaultModel || 'opencode/grok-code',
+      defaultModel: config.defaultModel || 'opencode/grok-code-fast',
     };
 
     // Set DEBUG_VERBOSE BEFORE creating logger so event handlers can check it


### PR DESCRIPTION
## Summary
- Fixes a regression where the eval runner default model could be `opencode/grok-code`, which is currently not available.
- Changes `evals/framework/src/sdk/test-runner.ts` fallback default to `opencode/grok-code-fast` to match the CLI’s documented default and current provider availability.

## Related Issue
- https://github.com/darrenhinde/OpenAgentsControl/issues/222

## Validation
- Requested independent review via `requesting-code-review` workflow style (delegate reviewer): passed.
- Verified diff is a single-line default-model fallback update.
- Ran focused tests:
  - `npx vitest run src/__tests__/error-handling.test.ts src/__tests__/framework-confidence.test.ts`
    - Result: 5 existing failures in repository baseline tests; none were from touched path (pre-existing).
  - `npm run build` in `evals/framework` currently reports pre-existing TS issues in integration/evaluator areas.
  - `npm run eval:sdk -- --help` currently fails on an existing test data issue (`invalid enum value` in a repository test fixture).

## Notes
- No schema/API changes.
- No new dependencies added.
